### PR TITLE
Shortest path search heuristic

### DIFF
--- a/src/path-symex/locs.cpp
+++ b/src/path-symex/locs.cpp
@@ -86,19 +86,23 @@ void locst::output(std::ostream &out) const
 {
   irep_idt function;
 
-  for(unsigned l=0; l<loc_vector.size(); l++)
+  for(std::size_t l = 0; l < loc_vector.size(); l++)
   {
-    const loct &loc=loc_vector[l];
-    if(function!=loc.function)
+    const loct &loc = loc_vector[l];
+    if(function != loc.function)
     {
-      function=loc.function;
+      function = loc.function;
       out << "*** " << function << "\n";
     }
 
     out << "  L" << l << ": "
 //        << loc.target->type << " "
 //        << loc.target->location
-        << " " << as_string(ns, *loc.target) << "\n";
+        << " " << as_string(ns, *loc.target);
+    if(loc_vector[l].distance_to_property
+        != std::numeric_limits<std::size_t>::max())
+      out << " path length: " << loc_vector[l].distance_to_property;
+    out << "\n";
 
     if(!loc.branch_target.is_nil())
       out << "    T: " << loc.branch_target << "\n";

--- a/src/path-symex/locs.cpp
+++ b/src/path-symex/locs.cpp
@@ -82,6 +82,39 @@ void locst::build(const goto_functionst &goto_functions)
   }
 }
 
+void locst::output_reachable(std::ostream &out) const
+{
+  irep_idt function;
+  int reachable_count = 0;
+  int unreachable_count = 0;
+
+  for(unsigned l = 0; l < loc_vector.size(); l++)
+  {
+    const loct &loc = loc_vector[l];
+    if(loc.distance_to_property != -1)
+    {
+      reachable_count++;
+      if(function != loc.function)
+      {
+        function = loc.function;
+        out << "*** " << function << "\n";
+      }
+
+      out << "  L" << l << ": " << " " << as_string(ns, *loc.target)
+          << " path length: " << loc_vector[l].distance_to_property << "\n";
+
+      if(!loc.branch_target.is_nil())
+        out << "    T: " << loc.branch_target << "\n";
+    }
+    else
+      unreachable_count++;
+  }
+  out << "\n";
+  out << "The entry location is L" << entry_loc << ".\n";
+  out << "Number of reachable locs " << reachable_count << "\n";
+  out << "Number of unreachable locs " << unreachable_count << "\n";
+}
+
 void locst::output(std::ostream &out) const
 {
   irep_idt function;

--- a/src/path-symex/locs.h
+++ b/src/path-symex/locs.h
@@ -59,6 +59,7 @@ public:
   explicit locst(const namespacet &_ns);
   void build(const goto_functionst &goto_functions);
   void output(std::ostream &out) const;
+  void output_reachable(std::ostream &out) const;
 
   loct &operator[] (loc_reft l)
   {

--- a/src/path-symex/locs.h
+++ b/src/path-symex/locs.h
@@ -27,11 +27,12 @@ public:
     target(_target),
     function(_function)
   {
+    distance_to_property=std::numeric_limits<std::size_t>::max();
   }
 
   goto_programt::const_targett target;
   irep_idt function;
-
+  std::size_t distance_to_property;
   // we only support a single branch target
   loc_reft branch_target;
 };

--- a/src/path-symex/path_symex_state.h
+++ b/src/path-symex/path_symex_state.h
@@ -208,6 +208,11 @@ public:
     return depth;
   }
 
+  unsigned get_shortest_path() const
+  {
+    return locs.loc_vector[pc().loc_number].distance_to_property;
+  }
+
   void increase_depth()
   {
     depth++;

--- a/src/symex/Makefile
+++ b/src/symex/Makefile
@@ -2,6 +2,7 @@ SRC = path_search.cpp \
       symex_cover.cpp \
       symex_main.cpp \
       symex_parse_options.cpp \
+      shortest_path_graph.cpp \
       # Empty last line
 
 OBJ += ../../$(CPROVER_DIR)/src/ansi-c/ansi-c$(LIBEXT) \

--- a/src/symex/path_search.cpp
+++ b/src/symex/path_search.cpp
@@ -130,6 +130,31 @@ path_searcht::resultt path_searcht::operator()(
 
   status() << "Starting symbolic simulation" << eom;
 
+  switch(search_heuristic)
+  {
+  case search_heuristict::DFS:
+    status() << "Search heuristic: DFS" << eom;
+    break;
+  case search_heuristict::RAN_DFS:
+    status() << "Search heuristic: randomized DFS" << eom;
+    break;
+  case search_heuristict::BFS:
+    status() << "Search heuristic: BFS" << eom;
+    break;
+  case search_heuristict::SHORTEST_PATH:
+    status() << "Search heuristic: shortest path" << eom;
+    break;
+  case search_heuristict::SHORTEST_PATH_PER_FUNC:
+    status() << "Search heuristic: shortest path per function" << eom;
+    break;
+  case search_heuristict::RAN_SHORTEST_PATH:
+    status() << "Search heuristic: randomized shortest path" << eom;
+    break;
+  case search_heuristict::LOCS:
+    status() << "Search heuristic: LOCS" << eom;
+    break;
+  }
+
   // this is the container for the history-forest
   path_symex_historyt history;
 
@@ -165,6 +190,11 @@ path_searcht::resultt path_searcht::operator()(
   statet init_state = initial_state(var_map, locs, history);
   queue.push_back(init_state);
   initial_distance_to_property=init_state.get_shortest_path();
+
+  time_periodt initialisation_time=current_time()-start_time;
+  status() << "Initialisation took "<< initialisation_time << "s" << eom;
+  start_time=current_time();
+  last_reported_time=start_time;
 
   while(!queue.empty())
   {

--- a/src/symex/path_search.cpp
+++ b/src/symex/path_search.cpp
@@ -20,6 +20,27 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <path-symex/path_symex.h>
 #include <path-symex/build_goto_trace.h>
 
+#include <random>
+
+void path_searcht::shuffle_queue(queuet &queue)
+{
+  if(queue.size()<=1)
+    return;
+
+  INVARIANT(queue.size()<std::numeric_limits<int>::max(),
+      "Queue size must be less than maximum integer");
+  // pick random state and move to front
+  int rand_i = rand() % queue.size();
+
+  std::list<statet>::iterator it = queue.begin();
+  for(int i=0; i<rand_i; i++)
+    it++;
+
+  statet tmp = *it;
+  queue.push_front(tmp);
+  queue.erase(it);
+}
+
 path_searcht::resultt path_searcht::operator()(
   const goto_functionst &goto_functions)
 {
@@ -142,6 +163,9 @@ path_searcht::resultt path_searcht::operator()(
       // execute
       path_symex(state, tmp_queue);
 
+      if(search_heuristic == search_heuristict::RAN_DFS)
+        shuffle_queue(tmp_queue);
+
       // put at head of main queue
       queue.splice(queue.begin(), tmp_queue);
     }
@@ -208,6 +232,7 @@ void path_searcht::pick_state()
   switch(search_heuristic)
   {
   case search_heuristict::DFS:
+  case search_heuristict::RAN_DFS:
     // Picking the first one (most recently added) is a DFS.
     return;
 

--- a/src/symex/path_search.h
+++ b/src/symex/path_search.h
@@ -116,6 +116,8 @@ public:
     { search_heuristic=search_heuristict::SHORTEST_PATH; }
   void set_ran_shortest_path()
     { search_heuristic=search_heuristict::RAN_SHORTEST_PATH; }
+  void set_shortest_path_per_function()
+    { search_heuristic=search_heuristict::SHORTEST_PATH_PER_FUNC; }
 
   typedef std::map<irep_idt, property_entryt> property_mapt;
   property_mapt property_map;
@@ -133,6 +135,7 @@ protected:
   /// Move element with shortest distance to property
   /// to the front of the queue
   void sort_queue();
+  void sort_queue_per_function();
   // search heuristic
   void pick_state();
 
@@ -164,7 +167,8 @@ protected:
   unsigned time_limit;
 
   enum class search_heuristict
-  { DFS, RAN_DFS, BFS, LOCS, SHORTEST_PATH, RAN_SHORTEST_PATH } search_heuristic;
+  { DFS, RAN_DFS, BFS, LOCS, SHORTEST_PATH,
+    RAN_SHORTEST_PATH , SHORTEST_PATH_PER_FUNC } search_heuristic;
 
   source_locationt last_source_location;
 };

--- a/src/symex/path_search.h
+++ b/src/symex/path_search.h
@@ -107,6 +107,7 @@ public:
   };
 
   void set_dfs() { search_heuristic=search_heuristict::DFS; }
+  void set_randomized_dfs() { search_heuristic=search_heuristict::RAN_DFS; }
   void set_bfs() { search_heuristic=search_heuristict::BFS; }
   void set_locs() { search_heuristic=search_heuristict::LOCS; }
 
@@ -120,7 +121,9 @@ protected:
   // The states most recently executed are at the head.
   typedef std::list<statet> queuet;
   queuet queue;
-
+  /// Pick random element of queue and move to front
+  /// \param queue  queue to be shuffled
+  void shuffle_queue(queuet &queue);
   // search heuristic
   void pick_state();
 
@@ -151,7 +154,8 @@ protected:
   unsigned unwind_limit;
   unsigned time_limit;
 
-  enum class search_heuristict { DFS, BFS, LOCS } search_heuristic;
+  enum class search_heuristict
+  { DFS, RAN_DFS, BFS, LOCS } search_heuristic;
 
   source_locationt last_source_location;
 };

--- a/src/symex/path_search.h
+++ b/src/symex/path_search.h
@@ -80,6 +80,8 @@ public:
   bool stop_on_fail;
 
   // statistics
+  unsigned current_distance;
+  unsigned initial_distance_to_property;
   std::size_t number_of_dropped_states;
   std::size_t number_of_paths;
   std::size_t number_of_steps;
@@ -110,6 +112,10 @@ public:
   void set_randomized_dfs() { search_heuristic=search_heuristict::RAN_DFS; }
   void set_bfs() { search_heuristic=search_heuristict::BFS; }
   void set_locs() { search_heuristic=search_heuristict::LOCS; }
+  void set_shortest_path()
+    { search_heuristic=search_heuristict::SHORTEST_PATH; }
+  void set_ran_shortest_path()
+    { search_heuristic=search_heuristict::RAN_SHORTEST_PATH; }
 
   typedef std::map<irep_idt, property_entryt> property_mapt;
   property_mapt property_map;
@@ -124,6 +130,9 @@ protected:
   /// Pick random element of queue and move to front
   /// \param queue  queue to be shuffled
   void shuffle_queue(queuet &queue);
+  /// Move element with shortest distance to property
+  /// to the front of the queue
+  void sort_queue();
   // search heuristic
   void pick_state();
 
@@ -155,7 +164,7 @@ protected:
   unsigned time_limit;
 
   enum class search_heuristict
-  { DFS, RAN_DFS, BFS, LOCS } search_heuristic;
+  { DFS, RAN_DFS, BFS, LOCS, SHORTEST_PATH, RAN_SHORTEST_PATH } search_heuristic;
 
   source_locationt last_source_location;
 };

--- a/src/symex/shortest_path_graph.cpp
+++ b/src/symex/shortest_path_graph.cpp
@@ -1,0 +1,88 @@
+/*******************************************************************\
+
+Module: Shortest path graph
+
+Author: elizabeth.polgreen@cs.ox.ac.uk
+
+\*******************************************************************/
+
+#include "shortest_path_graph.h"
+
+#include <algorithm>
+void shortest_path_grapht::bfs(node_indext property_index)
+{
+  // does BFS, not Dijkstra
+  // we hope the graph is sparse
+  std::vector<node_indext> frontier_set;
+
+  frontier_set.reserve(nodes.size());
+
+  frontier_set.push_back(property_index);
+  nodes[property_index].visited = true;
+
+  for(std::size_t d = 1; !frontier_set.empty(); ++d)
+  {
+    std::vector<node_indext> new_frontier_set;
+
+    for(const auto &node_index : frontier_set)
+    {
+      const nodet &n = nodes[node_index];
+
+      // do all neighbors
+      // we go backwards through the graph
+      for(const auto &edge_in : n.in)
+      {
+        node_indext node_in = edge_in.first;
+
+        if(!nodes[node_in].visited)
+        {
+          nodes[node_in].shortest_path_to_property = d;
+          nodes[node_in].visited = true;
+          new_frontier_set.push_back(node_in);
+        }
+      }
+    }
+
+    frontier_set.swap(new_frontier_set);
+  }
+}
+
+void shortest_path_grapht::write_lengths_to_locs()
+{
+  for(const auto &n : nodes)
+  {
+    loc_reft l = target_to_loc_map[n.PC];
+    locs.loc_vector[l.loc_number].distance_to_property
+        = n.shortest_path_to_property;
+  }
+}
+
+void shortest_path_grapht::get_path_lengths_to_property()
+{
+  node_indext property_index;
+  bool found_property=false;
+  for(node_indext n=0; n<nodes.size(); n++)
+  {
+    if(nodes[n].PC->is_assert())
+    {
+      if(found_property == false)
+      {
+        nodes[n].is_property = true;
+        nodes[n].shortest_path_to_property = 0;
+        working_set.insert(n);
+        property_index = n;
+        found_property = true;
+      }
+      else
+        throw "shortest path search cannot be used for multiple properties";
+    }
+  }
+  if(!found_property)
+    throw "unable to find property";
+
+  bfs(property_index);
+
+  write_lengths_to_locs();
+}
+
+

--- a/src/symex/shortest_path_graph.cpp
+++ b/src/symex/shortest_path_graph.cpp
@@ -9,6 +9,56 @@ Author: elizabeth.polgreen@cs.ox.ac.uk
 #include "shortest_path_graph.h"
 
 #include <algorithm>
+
+void shortest_path_grapht::get_path_lengths_in_function()
+{
+  bool found_property = false;
+  bool found_end = false;
+  node_indext end_index;
+  node_indext property_index;
+  node_indext index = 0;
+  for(auto &n : nodes)
+  {
+    if(n.PC->is_assert())
+    {
+      if(found_property == false)
+      {
+        n.is_property = true;
+        n.shortest_path_to_property = 0;
+        found_property = true;
+        property_index = index;
+      }
+      else
+        throw "shortest path search cannot be used with multiple properties";
+    }
+    if(n.PC->is_end_function())
+    {
+      end_index = index;
+      found_end = true;
+    }
+    index++;
+  }
+
+  if(!found_property)
+  {
+    nodes[end_index].shortest_path_to_property = 0;
+    bfs(end_index);
+  }
+  else
+    bfs(property_index);
+
+  write_lengths_to_locs();
+}
+
+void per_function_shortest_patht::build(const goto_functionst &goto_functions)
+{
+  forall_goto_functions(it, goto_functions)
+    if(it->second.body_available())
+    {
+      shortest_path_grapht path_graph(it->second.body, locs);
+    }
+}
+
 void shortest_path_grapht::bfs(node_indext property_index)
 {
   // does BFS, not Dijkstra

--- a/src/symex/shortest_path_graph.h
+++ b/src/symex/shortest_path_graph.h
@@ -49,6 +49,15 @@ public:
     get_path_lengths_to_property();
     }
 
+  explicit shortest_path_grapht(
+      const goto_programt &_goto_program, locst &_locs):
+    locs(_locs),
+    target_to_loc_map(_locs)
+    {
+    cfg_baset<shortest_path_nodet>::operator()(_goto_program);
+    get_path_lengths_in_function();
+    }
+
 protected:
   /// \brief writes the computed shortest path for every node
   /// in the graph to the corresponding location in locst.
@@ -60,6 +69,11 @@ protected:
   /// is present, we use the first one discovered.
   /// Calls bfs() to do this.
   void get_path_lengths_to_property();
+  /// \brief computes the shortest path from every node in a
+  /// graph to the property, or the end of the funciton if
+  /// there is no property.
+  /// we assume the graph is a graph of a single function.
+  void get_path_lengths_in_function();
   /// \brief implements backwards BFS to compute distance from every node in
   /// the graph to the node index given as parameter
   /// \param destination node index
@@ -67,6 +81,29 @@ protected:
   std::set<node_indext> working_set;
   locst &locs;
   target_to_loc_mapt target_to_loc_map;
+};
+
+/// \brief class contains CFG of program locations
+/// for every function with the shortest distance to a
+/// property, or the end of a function, calculated for each location
+/// The distances computed for each node are written to the corresponding
+/// loct in the locst passed as param to the constructor. This allows us
+/// to use these numbers to guide a symex search
+/// \param goto functions to create the CFGs from, locs struct made from the
+/// same goto_functions
+class per_function_shortest_patht
+{
+public:
+  explicit per_function_shortest_patht(
+      const goto_functionst &_goto_functions, locst &_locs):
+  locs(_locs)
+  {
+    build(_goto_functions);
+  }
+
+protected:
+  locst &locs;
+  void build(const goto_functionst & goto_functions);
 };
 
 #endif /* CPROVER_SYMEX_SHORTEST_PATH_GRAPH_H */

--- a/src/symex/shortest_path_graph.h
+++ b/src/symex/shortest_path_graph.h
@@ -1,0 +1,72 @@
+/*******************************************************************\
+
+Module: Shortest path graph
+
+Author: elizabeth.polgreen@cs.ox.ac.uk
+
+\*******************************************************************/
+
+#ifndef CPROVER_SYMEX_SHORTEST_PATH_GRAPH_H
+#define CPROVER_SYMEX_SHORTEST_PATH_GRAPH_H
+
+#include <goto-programs/cfg.h>
+#include <path-symex/locs.h>
+#include <goto-programs/goto_model.h>
+#include <limits>
+
+
+struct shortest_path_nodet
+{
+  bool visited;
+  std::size_t shortest_path_to_property;
+  bool is_property;
+  shortest_path_nodet():
+    visited(false),
+    is_property(false)
+  {
+    shortest_path_to_property = std::numeric_limits<std::size_t>::max();
+  }
+};
+
+/// \brief constructs a CFG of all program locations. Then computes
+/// the shortest path from every program location to a single property.
+/// WARNING: if more than one property is present in the graph, we will
+/// use the first property found
+/// The distances computed for each node are written to the corresponding
+/// loct in the locst passed as param to the constructor. This allows us
+/// to use these numbers to guide a symex search
+/// \param goto functions to create the CFG from, locs struct made from the
+/// same goto_functions
+class shortest_path_grapht: public cfg_baset<shortest_path_nodet>
+{
+public:
+  explicit shortest_path_grapht(
+      const goto_functionst &_goto_functions, locst &_locs):
+    locs(_locs),
+    target_to_loc_map(_locs)
+    {
+    cfg_baset<shortest_path_nodet>::operator()(_goto_functions);
+    get_path_lengths_to_property();
+    }
+
+protected:
+  /// \brief writes the computed shortest path for every node
+  /// in the graph to the corresponding location in locst.
+  /// This is done so that we can use these numbers to guide
+  /// a search heuristic for symex
+  void write_lengths_to_locs();
+  /// \brief computes the shortest path from every node in
+  /// the graph to a single property. WARNING: if more than one property
+  /// is present, we use the first one discovered.
+  /// Calls bfs() to do this.
+  void get_path_lengths_to_property();
+  /// \brief implements backwards BFS to compute distance from every node in
+  /// the graph to the node index given as parameter
+  /// \param destination node index
+  void bfs(node_indext property_index);
+  std::set<node_indext> working_set;
+  locst &locs;
+  target_to_loc_mapt target_to_loc_map;
+};
+
+#endif /* CPROVER_SYMEX_SHORTEST_PATH_GRAPH_H */

--- a/src/symex/symex_parse_options.cpp
+++ b/src/symex/symex_parse_options.cpp
@@ -58,6 +58,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <path-symex/locs.h>
 
 #include "path_search.h"
+#include "shortest_path_graph.h"
 
 symex_parse_optionst::symex_parse_optionst(int argc, const char **argv):
   parse_options_baset(SYMEX_OPTIONS, argc, argv),
@@ -199,6 +200,18 @@ int symex_parse_optionst::doit()
     locst locs(ns);
     locs.build(goto_model.goto_functions);
     locs.output(std::cout);
+    return 0;
+  }
+
+  if(cmdline.isset("show-distances-to-property"))
+  {
+    const namespacet ns(goto_model.symbol_table);
+    locst locs(ns);
+    locs.build(goto_model.goto_functions);
+
+    shortest_path_grapht path_search_graph(goto_model.goto_functions, locs);
+
+    locs.output_reachable(std::cout);
     return 0;
   }
 
@@ -647,6 +660,8 @@ void symex_parse_optionst::help()
     " --eager-infeasibility        query solver early to determine whether a path is infeasible before searching it\n" // NOLINT(*)
     "\n"
     "Other options:\n"
+    " --show-distances-to-property\n"
+    "                              shows the (context free) shortest path from every reachable program location to a single property" // NOLINT(*)
     " --version                    show version and exit\n"
     " --xml-ui                     use XML-formatted output\n"
     " --verbosity #                verbosity level\n"

--- a/src/symex/symex_parse_options.cpp
+++ b/src/symex/symex_parse_options.cpp
@@ -265,6 +265,10 @@ int symex_parse_optionst::doit()
       else
         path_search.set_shortest_path();
     }
+
+    if(cmdline.isset("shortest-path-per-function"))
+      path_search.set_shortest_path_per_function();
+
     if(cmdline.isset("show-vcc"))
     {
       path_search.show_vcc=true;
@@ -664,6 +668,7 @@ void symex_parse_optionst::help()
     " --dfs                        use depth first search\n"
     " --bfs                        use breadth first search\n"
     "--shortest-path               use shortest path guided search\n"
+    "--shortest-path-per-function  computes shortest path locally and uses to guide symex search\n" // NOLINT(*)
     " --randomize                  in conjunction with dfs to use randomized dfs\n" // NOLINT(*)
 	  "                              in conjunction with shortest path to use randomized shortest path guided search\n" // NOLINT(*)
     " --eager-infeasibility        query solver early to determine whether a path is infeasible before searching it\n" // NOLINT(*)

--- a/src/symex/symex_parse_options.cpp
+++ b/src/symex/symex_parse_options.cpp
@@ -232,7 +232,12 @@ int symex_parse_optionst::doit()
         safe_string2unsigned(cmdline.get_value("max-search-time")));
 
     if(cmdline.isset("dfs"))
-      path_search.set_dfs();
+    {
+      if(cmdline.isset("randomize"))
+        path_search.set_randomized_dfs();
+      else
+        path_search.set_dfs();
+    }
 
     if(cmdline.isset("bfs"))
       path_search.set_bfs();
@@ -638,6 +643,7 @@ void symex_parse_optionst::help()
     " --max-search-time s          limit search to approximately s seconds\n"
     " --dfs                        use depth first search\n"
     " --bfs                        use breadth first search\n"
+    " --randomize                  used in conjunction with dfs, to search by randomized dfs\n" // NOLINT(*)
     " --eager-infeasibility        query solver early to determine whether a path is infeasible before searching it\n" // NOLINT(*)
     "\n"
     "Other options:\n"

--- a/src/symex/symex_parse_options.cpp
+++ b/src/symex/symex_parse_options.cpp
@@ -258,6 +258,13 @@ int symex_parse_optionst::doit()
     if(cmdline.isset("locs"))
       path_search.set_locs();
 
+    if(cmdline.isset("shortest-path"))
+    {
+      if(cmdline.isset("randomize"))
+        path_search.set_ran_shortest_path();
+      else
+        path_search.set_shortest_path();
+    }
     if(cmdline.isset("show-vcc"))
     {
       path_search.show_vcc=true;
@@ -656,7 +663,9 @@ void symex_parse_optionst::help()
     " --max-search-time s          limit search to approximately s seconds\n"
     " --dfs                        use depth first search\n"
     " --bfs                        use breadth first search\n"
-    " --randomize                  used in conjunction with dfs, to search by randomized dfs\n" // NOLINT(*)
+    "--shortest-path               use shortest path guided search\n"
+    " --randomize                  in conjunction with dfs to use randomized dfs\n" // NOLINT(*)
+	  "                              in conjunction with shortest path to use randomized shortest path guided search\n" // NOLINT(*)
     " --eager-infeasibility        query solver early to determine whether a path is infeasible before searching it\n" // NOLINT(*)
     "\n"
     "Other options:\n"

--- a/src/symex/symex_parse_options.cpp
+++ b/src/symex/symex_parse_options.cpp
@@ -636,6 +636,9 @@ void symex_parse_optionst::help()
     " --context-bound nr           limit number of context switches\n"
     " --branch-bound nr            limit number of branches taken\n"
     " --max-search-time s          limit search to approximately s seconds\n"
+    " --dfs                        use depth first search\n"
+    " --bfs                        use breadth first search\n"
+    " --eager-infeasibility        query solver early to determine whether a path is infeasible before searching it\n" // NOLINT(*)
     "\n"
     "Other options:\n"
     " --version                    show version and exit\n"

--- a/src/symex/symex_parse_options.h
+++ b/src/symex/symex_parse_options.h
@@ -41,6 +41,7 @@ class optionst;
   "(error-label):(verbosity):(no-library)" \
   "(version)" \
   "(bfs)(dfs)(locs)(shortest-path)" \
+  "(shortest-path-per-function)" \
   "(randomize)" \
   "(cover):" \
   "(i386-linux)(i386-macos)(i386-win32)(win32)(winx64)(gcc)" \

--- a/src/symex/symex_parse_options.h
+++ b/src/symex/symex_parse_options.h
@@ -41,6 +41,7 @@ class optionst;
   "(error-label):(verbosity):(no-library)" \
   "(version)" \
   "(bfs)(dfs)(locs)" \
+  "(randomize)" \
   "(cover):" \
   "(i386-linux)(i386-macos)(i386-win32)(win32)(winx64)(gcc)" \
   "(ppc-macos)(unsigned-char)" \

--- a/src/symex/symex_parse_options.h
+++ b/src/symex/symex_parse_options.h
@@ -51,6 +51,7 @@ class optionst;
   "(show-locs)(show-vcc)(show-properties)(show-symbol-table)" \
   "(drop-unused-functions)" \
   "(object-bits):" \
+  "(show-distances-to-property)" \
   OPT_SHOW_GOTO_FUNCTIONS \
   "(property):(trace)(show-trace)(stop-on-fail)(eager-infeasibility)" \
   "(no-simplify)(no-unwinding-assertions)(no-propagation)" \

--- a/src/symex/symex_parse_options.h
+++ b/src/symex/symex_parse_options.h
@@ -40,7 +40,7 @@ class optionst;
   "(little-endian)(big-endian)" \
   "(error-label):(verbosity):(no-library)" \
   "(version)" \
-  "(bfs)(dfs)(locs)" \
+  "(bfs)(dfs)(locs)(shortest-path)" \
   "(randomize)" \
   "(cover):" \
   "(i386-linux)(i386-macos)(i386-win32)(win32)(winx64)(gcc)" \


### PR DESCRIPTION
Introduces shortest_path_grapht class, which computes the shortest path from every program location to a single property (note this only works with 1 property, and a warning is given if more than one property is present in the program), stores these numbers in locst.

These numbers are then used to guide the symex search heuristic (this is why i only implemented this for one property, the search heuristic becomes less effective with multiple properties). 

The shortest path per function computes either the shortest path to the property, if the property is within that function, or the shortest path to the end of the function. 